### PR TITLE
Migrated code to not clear the view container on every update

### DIFF
--- a/src/app/reexportr-src/reexportr.directive.ts
+++ b/src/app/reexportr-src/reexportr.directive.ts
@@ -1,17 +1,39 @@
-import { Directive, Input, TemplateRef, ViewContainerRef } from "@angular/core";
+import {
+  Directive,
+  Input,
+  TemplateRef,
+  ViewContainerRef,
+  OnInit,
+  OnDestroy,
+  EmbeddedViewRef
+} from "@angular/core";
 
 @Directive({
   selector: "[reExportr]"
 })
-export class ReExportrDirective {
+export class ReExportrDirective implements OnInit, OnDestroy {
+  context = {
+    $implicit: undefined,
+    reExportr: undefined
+  };
+  embeddedView: EmbeddedViewRef<any>;
+
   constructor(private _tr: TemplateRef<any>, private _vcr: ViewContainerRef) {}
+
+  ngOnInit() {
+    this.embeddedView = this._vcr.createEmbeddedView(this._tr, this.context);
+  }
+
+  ngOnDestroy() {
+    this._vcr.clear();
+  }
 
   @Input()
   set reExportr(val: any) {
-    this._vcr.clear();
-    this._vcr.createEmbeddedView(this._tr, {
-      $implicit: val,
-      reExportr: val
-    });
+    this.context.reExportr = val;
+    this.context.$implicit = val;
+    if (this.embeddedView) {
+      this.embeddedView.detectChanges();
+    }
   }
 }

--- a/src/app/reexportr-src/reexportr.directive.ts
+++ b/src/app/reexportr-src/reexportr.directive.ts
@@ -11,7 +11,7 @@ import {
 @Directive({
   selector: "[reExportr]"
 })
-export class ReExportrDirective implements OnInit, OnDestroy {
+export class ReExportrDirective implements OnInit {
   context = {
     $implicit: undefined,
     reExportr: undefined
@@ -24,16 +24,9 @@ export class ReExportrDirective implements OnInit, OnDestroy {
     this.embeddedView = this._vcr.createEmbeddedView(this._tr, this.context);
   }
 
-  ngOnDestroy() {
-    this._vcr.clear();
-  }
-
   @Input()
   set reExportr(val: any) {
     this.context.reExportr = val;
     this.context.$implicit = val;
-    if (this.embeddedView) {
-      this.embeddedView.detectChanges();
-    }
   }
 }


### PR DESCRIPTION
Looking at the code from this directive (as well as https://www.npmjs.com/package/ngx-let-directive and a few other packages that do similar to this), I quickly noticed that on every page render, it is clearing the entire view container and re-rendering the entire thing, regardless of if all of the data there-within requires changes or not. This breaks the pattern of change detection that Angular has built in. I figured I'd make a PR to fix this and utilize the internal change detection to handle change handling

The result is a 10x speedup in one of the small examples I threw together:

```typescript
import { Component } from '@angular/core';

@Component({
  selector: 'my-app',
  template: `
  <input placeholder="Change the value" [(ngModel)]="input"/>

<ng-container *reExportr="(input | uppercase) as upper">
	<h1>{{upper}}</h1>
  <p *ngFor="let val of array">This is a long counting message, there should be a lot of them {{val}}</p>
</ng-container>
  `
})
export class AppComponent  {
  input = '';

  array = Array.from(new Array(10000), (_, i) => i)
}

```

In this example, rendering a LOT of content on-screen that doesn't rely on the changed value.

Before:
https://stackblitz.com/edit/angularnglet-old

![A performance benchmark showing 1139ms in rendering time and 2675ms of scripting time](https://user-images.githubusercontent.com/9100169/70367915-f03e6b80-1859-11ea-9d17-8aec428d471f.png)

After:

https://stackblitz.com/edit/angularnglet

![A performance benchmark showing 131ms in rendering time and 268ms of scripting time](https://user-images.githubusercontent.com/9100169/70367923-0ba97680-185a-11ea-892b-18c4ddbfebf4.png)

In this (admittedly extreme) example, we're seeing a ~10x speedup